### PR TITLE
Update to selector for hoopladigital.com connector

### DIFF
--- a/src/connectors/hoopladigital.js
+++ b/src/connectors/hoopladigital.js
@@ -2,7 +2,7 @@
 
 Connector.playerSelector = '#app'; // .duration-700 player wrapper is destroyed when album ends
 
-Connector.playButtonSelector = 'button[aria-label=Play]';
+Connector.pauseButtonSelector = 'button[aria-label=Pause]';
 
 Connector.trackSelector = '.text-current > p:first-of-type';
 


### PR DESCRIPTION
Minor update to replace `playButtonSelector` with `pauseButtonSelector` for better `isPlaying` handling.

Button is sometimes briefly replaced by "Loading…" text, which can momentarily throw off `isPlaying` status when monitoring Play instead of Pause.
<img width="288" alt="" src="https://user-images.githubusercontent.com/6808988/185707575-277947c2-e148-492c-8465-9172b484097d.png">

This is obviously very minor and current connector is working, so no rush on releasing this, either.